### PR TITLE
feat(claude): 支持在新标签页打开网页

### DIFF
--- a/scripts/verify-browser-privacy-ui.js
+++ b/scripts/verify-browser-privacy-ui.js
@@ -92,6 +92,7 @@ async function main() {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sharegpt-privacy-ui-"));
   const userDataDir = path.join(tempDir, "user-data");
   const screenshotPath = path.join(tempDir, "browser-privacy-account.png");
+  const claudeScreenshotPath = path.join(tempDir, "claude-address-bar.png");
   const port = await reservePort();
   const baseUrl = `http://127.0.0.1:${port}`;
   const usersFile = path.join(tempDir, "users.json");
@@ -239,6 +240,26 @@ async function main() {
     assert.strictEqual(Object.hasOwn(syncedPrivacy, "audit"), false);
 
     await window.screenshot({ path: screenshotPath, fullPage: true });
+
+    await window.locator('[data-tour="nav-claude"]').click();
+    const claudeAddressInput = window.getByTestId("claude-address-input");
+    await claudeAddressInput.waitFor({ state: "visible" });
+    assert.strictEqual(
+      await claudeAddressInput.isDisabled(),
+      true,
+      "Claude address input must stay disabled while the sender proxy is stopped",
+    );
+    const openWebPageButton = window.getByRole("button", {
+      name: "在新标签页打开",
+      exact: true,
+    });
+    assert.strictEqual(
+      await openWebPageButton.isDisabled(),
+      true,
+      "Claude open-page action must stay disabled while the sender proxy is stopped",
+    );
+    await window.screenshot({ path: claudeScreenshotPath, fullPage: true });
+
     assert.deepStrictEqual(pageErrors, [], `renderer page errors: ${pageErrors.join("; ")}`);
     assert.ok(
       blockedRequests.every((url) => !/claude\.ai|chatgpt\.com|gemini\.google\.com/i.test(url)),
@@ -264,6 +285,8 @@ async function main() {
           aiWebsitesVisited: false,
           blockedNonLocalRequests: blockedRequests.length,
           screenshot: screenshotPath,
+          claudeAddressBarPresent: true,
+          claudeAddressBarScreenshot: claudeScreenshotPath,
         },
         null,
         2,

--- a/src/main/aiNavigation.js
+++ b/src/main/aiNavigation.js
@@ -1,0 +1,37 @@
+function normalizeHttpUrl(rawUrl, options = {}) {
+  let value = String(rawUrl || "").trim();
+  if (!value) return "";
+
+  if (options.assumeHttps && !/^[a-z][a-z\d+.-]*:/i.test(value)) {
+    value = `https://${value}`;
+  }
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return "";
+    return url.toString();
+  } catch {
+    return "";
+  }
+}
+
+function isAllowedUrlForHosts(rawUrl, allowedHosts) {
+  const normalized = normalizeHttpUrl(rawUrl);
+  if (!normalized) return false;
+  const url = new URL(normalized);
+  return (allowedHosts || []).some(
+    (host) => url.hostname === host || url.hostname.endsWith(`.${host}`),
+  );
+}
+
+function isWorkspaceUrlAllowed(workspace, rawUrl) {
+  if (!normalizeHttpUrl(rawUrl)) return false;
+  if (workspace?.kind === "claude" && workspace?.allowExternalBrowsing) return true;
+  return isAllowedUrlForHosts(rawUrl, workspace?.policy?.allowedHosts || []);
+}
+
+module.exports = {
+  isAllowedUrlForHosts,
+  isWorkspaceUrlAllowed,
+  normalizeHttpUrl,
+};

--- a/src/main/appFactory.js
+++ b/src/main/appFactory.js
@@ -31,6 +31,7 @@ const {
   normalizeAiPartition,
   partitionForProfile,
 } = require("./browserFingerprint");
+const { isAllowedUrlForHosts, isWorkspaceUrlAllowed, normalizeHttpUrl } = require("./aiNavigation");
 
 // 记录每个 AI 会话(按 partition)实际访问过的主机名, 供「代理检测」展示页面流量去向。
 // 在 configureAiSession 内通过 webRequest 被动收集 (每个 partition 仅装一次)。
@@ -337,26 +338,8 @@ function buildClipboardAttachmentPayload() {
   return null;
 }
 
-function isAllowedUrlForHosts(rawUrl, allowedHosts) {
-  try {
-    const url = new URL(String(rawUrl || ""));
-    if (!/^https?:$/i.test(url.protocol)) return false;
-    return allowedHosts.some((host) => url.hostname === host || url.hostname.endsWith(`.${host}`));
-  } catch {
-    return false;
-  }
-}
-
 function normalizeExternalUrl(rawUrl) {
-  try {
-    const url = new URL(String(rawUrl || "").trim());
-    if (!/^https?:$/i.test(url.protocol)) {
-      return "";
-    }
-    return url.toString();
-  } catch {
-    return "";
-  }
+  return normalizeHttpUrl(rawUrl);
 }
 
 // 把 Sec-CH-UA / Sec-CH-UA-Full-Version-List 里的 "Electron" 品牌洗成真实 Chrome:
@@ -754,7 +737,7 @@ function createElectronApp(baseMode = "all") {
 
     const wc = workspace.view.webContents;
     const currentUrl = safeText(wc.getURL()) || workspace.lastUrl || workspace.policy.homeUrl;
-    if (!isAllowedUrlForHosts(currentUrl, workspace.policy.allowedHosts)) {
+    if (!isWorkspaceUrlAllowed(workspace, currentUrl)) {
       throw new Error("网页仍在初始化，请等待页面打开后再采集");
     }
     const targetSession = session.fromPartition(workspace.policy.partition);
@@ -826,15 +809,13 @@ function createElectronApp(baseMode = "all") {
 
   function isWorkspaceDocumentAllowed(workspace) {
     const currentUrl = safeText(workspace?.view?.webContents?.getURL?.());
-    return Boolean(
-      currentUrl && isAllowedUrlForHosts(currentUrl, workspace?.policy?.allowedHosts || []),
-    );
+    return Boolean(currentUrl && isWorkspaceUrlAllowed(workspace, currentUrl));
   }
 
   function getAiStatePayload(workspace) {
     const wc = workspace.view.webContents;
     const currentUrl = safeText(wc.getURL()) || workspace.lastUrl || workspace.policy.homeUrl;
-    if (currentUrl && isAllowedUrlForHosts(currentUrl, workspace.policy.allowedHosts)) {
+    if (currentUrl && isWorkspaceUrlAllowed(workspace, currentUrl)) {
       workspace.lastUrl = currentUrl;
     }
 
@@ -856,6 +837,7 @@ function createElectronApp(baseMode = "all") {
       initialized: Boolean(workspace.initialized),
       canGoBack: Boolean(canGoBack),
       canGoForward: Boolean(canGoForward),
+      allowExternalBrowsing: Boolean(workspace.allowExternalBrowsing),
     };
   }
 
@@ -923,6 +905,7 @@ function createElectronApp(baseMode = "all") {
     const workspace = getOrCreateAiWorkspace(targetKind, safeText(options.tabId), {
       title: safeText(options.title),
       lastUrl: safeText(options.lastUrl),
+      allowExternalBrowsing: Boolean(options.allowExternalBrowsing),
     });
 
     const order = tabOrderByKind[targetKind];
@@ -1044,7 +1027,11 @@ function createElectronApp(baseMode = "all") {
   }
 
   async function loadAiWorkspaceUrl(workspace, rawUrl) {
-    const targetUrl = normalizeAiWorkspaceUrl(workspace, rawUrl) || workspace.policy.homeUrl;
+    const normalizedUrl = normalizeHttpUrl(rawUrl);
+    if (!normalizedUrl || !isWorkspaceUrlAllowed(workspace, normalizedUrl)) {
+      throw new Error("不允许加载该页面");
+    }
+    const targetUrl = normalizeAiWorkspaceUrl(workspace, normalizedUrl);
     workspace.managedNavigationCount = (workspace.managedNavigationCount || 0) + 1;
     try {
       return await loadUrlWithTransientRetry(() =>
@@ -1071,7 +1058,7 @@ function createElectronApp(baseMode = "all") {
     const wc = workspace.view.webContents;
 
     wc.setWindowOpenHandler(({ url }) => {
-      if (isAllowedUrlForHosts(url, workspace.policy.allowedHosts)) {
+      if (isWorkspaceUrlAllowed(workspace, url)) {
         const targetUrl = normalizeAiWorkspaceUrl(workspace, url);
         workspace.loading = true;
         workspace.initialized = true;
@@ -1093,7 +1080,7 @@ function createElectronApp(baseMode = "all") {
     });
 
     wc.on("will-navigate", (event, url) => {
-      if (isAllowedUrlForHosts(url, workspace.policy.allowedHosts)) {
+      if (isWorkspaceUrlAllowed(workspace, url)) {
         const targetUrl = normalizeAiWorkspaceUrl(workspace, url);
         if (targetUrl === url) return;
         event.preventDefault();
@@ -1116,7 +1103,7 @@ function createElectronApp(baseMode = "all") {
     });
 
     wc.on("will-redirect", (event, url) => {
-      if (isAllowedUrlForHosts(url, workspace.policy.allowedHosts)) {
+      if (isWorkspaceUrlAllowed(workspace, url)) {
         const targetUrl = normalizeAiWorkspaceUrl(workspace, url);
         if (targetUrl === url) return;
         event.preventDefault();
@@ -1212,13 +1199,10 @@ function createElectronApp(baseMode = "all") {
     });
 
     wc.on("did-navigate", (_event, url) => {
-      if (
-        workspace.environmentBootstrapping ||
-        !isAllowedUrlForHosts(url, workspace.policy.allowedHosts)
-      ) {
+      if (workspace.environmentBootstrapping || !isWorkspaceUrlAllowed(workspace, url)) {
         return;
       }
-      if (isAllowedUrlForHosts(url, workspace.policy.allowedHosts)) {
+      if (isWorkspaceUrlAllowed(workspace, url)) {
         workspace.lastUrl = normalizeAiWorkspaceUrl(workspace, url);
       }
       workspace.initialized = true;
@@ -1226,13 +1210,10 @@ function createElectronApp(baseMode = "all") {
     });
 
     wc.on("did-navigate-in-page", (_event, url) => {
-      if (
-        workspace.environmentBootstrapping ||
-        !isAllowedUrlForHosts(url, workspace.policy.allowedHosts)
-      ) {
+      if (workspace.environmentBootstrapping || !isWorkspaceUrlAllowed(workspace, url)) {
         return;
       }
-      if (isAllowedUrlForHosts(url, workspace.policy.allowedHosts)) {
+      if (isWorkspaceUrlAllowed(workspace, url)) {
         workspace.lastUrl = normalizeAiWorkspaceUrl(workspace, url);
       }
       emitAiState(workspace, "did-navigate-in-page", { url });
@@ -1448,6 +1429,7 @@ function createElectronApp(baseMode = "all") {
       loading: false,
       visible: false,
       lastUrl: safeText(options.lastUrl) || policy.homeUrl,
+      allowExternalBrowsing: targetKind === "claude" && Boolean(options.allowExternalBrowsing),
       defaultTitle: normalizeAiTabTitle(safeText(options.title), defaultTitleForKind(targetKind)),
       title: normalizeAiTabTitle(safeText(options.title), defaultTitleForKind(targetKind)),
       proxySignature: "",
@@ -1770,6 +1752,7 @@ function createElectronApp(baseMode = "all") {
       const workspace = createTabWorkspace(kind, {
         title: safeText(payload?.title),
         lastUrl: safeText(payload?.lastUrl),
+        allowExternalBrowsing: Boolean(payload?.allowExternalBrowsing),
       });
       activeTabIdByKind[kind] = workspace.id;
       syncActiveWorkspace(kind);
@@ -1809,6 +1792,7 @@ function createElectronApp(baseMode = "all") {
       }
       const workspace = getOrCreateAiWorkspace(kind, requestedTabId || activeTabIdByKind[kind], {
         lastUrl: safeText(payload?.lastUrl),
+        allowExternalBrowsing: Boolean(payload?.allowExternalBrowsing),
       });
       if (!activeTabIdByKind[kind]) {
         activeTabIdByKind[kind] = workspace.id;
@@ -1845,18 +1829,15 @@ function createElectronApp(baseMode = "all") {
       const targetUrl =
         normalizeAiWorkspaceUrl(
           workspace,
-          isAllowedUrlForHosts(lastUrl, workspace.policy.allowedHosts)
+          isWorkspaceUrlAllowed(workspace, lastUrl)
             ? lastUrl
-            : isAllowedUrlForHosts(homeUrl, workspace.policy.allowedHosts)
+            : isWorkspaceUrlAllowed(workspace, homeUrl)
               ? homeUrl
               : workspace.policy.homeUrl,
         ) || workspace.policy.homeUrl;
 
       const currentWorkspaceUrl = safeText(workspace.view.webContents.getURL());
-      if (
-        !workspace.initialized ||
-        !isAllowedUrlForHosts(currentWorkspaceUrl, workspace.policy.allowedHosts)
-      ) {
+      if (!workspace.initialized || !isWorkspaceUrlAllowed(workspace, currentWorkspaceUrl)) {
         workspace.initialized = false;
         workspace.loading = true;
         workspace.lastUrl = targetUrl;
@@ -2063,7 +2044,7 @@ function createElectronApp(baseMode = "all") {
           wc.reload();
           break;
         case "load":
-          if (!isAllowedUrlForHosts(url, workspace.policy.allowedHosts)) {
+          if (!isWorkspaceUrlAllowed(workspace, url)) {
             throw new Error("不允许加载该页面");
           }
           const targetUrl = normalizeAiWorkspaceUrl(workspace, url);

--- a/src/main/test/aiNavigation.test.js
+++ b/src/main/test/aiNavigation.test.js
@@ -1,0 +1,54 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const {
+  isAllowedUrlForHosts,
+  isWorkspaceUrlAllowed,
+  normalizeHttpUrl,
+} = require("../aiNavigation");
+
+test("用户输入的网址只接受 HTTP/HTTPS，并可自动补 HTTPS", () => {
+  assert.strictEqual(
+    normalizeHttpUrl("example.com/verify?code=abc", { assumeHttps: true }),
+    "https://example.com/verify?code=abc",
+  );
+  assert.strictEqual(normalizeHttpUrl("http://example.com/path"), "http://example.com/path");
+  assert.strictEqual(normalizeHttpUrl("javascript:alert(1)", { assumeHttps: true }), "");
+  assert.strictEqual(normalizeHttpUrl("file:///tmp/code.html", { assumeHttps: true }), "");
+  assert.strictEqual(normalizeHttpUrl("not a valid host", { assumeHttps: true }), "");
+});
+
+test("普通 AI 标签继续使用域名白名单", () => {
+  assert.strictEqual(isAllowedUrlForHosts("https://claude.ai/chat", ["claude.ai"]), true);
+  assert.strictEqual(isAllowedUrlForHosts("https://auth.claude.ai/login", ["claude.ai"]), true);
+  assert.strictEqual(isAllowedUrlForHosts("https://example.com/verify", ["claude.ai"]), false);
+});
+
+test("只有显式创建的 Claude 外部网页标签允许任意 HTTP/HTTPS", () => {
+  const policy = { allowedHosts: ["claude.ai"] };
+  assert.strictEqual(
+    isWorkspaceUrlAllowed({ kind: "claude", policy }, "https://example.com/verify"),
+    false,
+  );
+  assert.strictEqual(
+    isWorkspaceUrlAllowed(
+      { kind: "claude", policy, allowExternalBrowsing: true },
+      "https://example.com/verify",
+    ),
+    true,
+  );
+  assert.strictEqual(
+    isWorkspaceUrlAllowed(
+      { kind: "gpt", policy, allowExternalBrowsing: true },
+      "https://example.com/verify",
+    ),
+    false,
+  );
+  assert.strictEqual(
+    isWorkspaceUrlAllowed(
+      { kind: "claude", policy, allowExternalBrowsing: true },
+      "data:text/html,unsafe",
+    ),
+    false,
+  );
+});

--- a/src/renderer-next/src/components/panels/ai/AiWorkspace.tsx
+++ b/src/renderer-next/src/components/panels/ai/AiWorkspace.tsx
@@ -12,12 +12,15 @@ import {
   ShieldAlert,
   ShieldX,
   Loader2,
+  Globe2,
+  ArrowUpRight,
   X,
   type LucideIcon,
 } from 'lucide-react'
 import { ChatGPTIcon, ClaudeIcon, GeminiIcon } from '@/components/icons/AiBrandIcons'
 import { PanelScaffold } from '@/components/panels/PanelScaffold'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import type { AiProxyReport } from '@/types/api'
@@ -41,6 +44,7 @@ import {
   normalizeGptUrl,
   normalizeGeminiUrl,
   normalizeClaudeUrl,
+  normalizeHttpUrl,
 } from './constants'
 import type { AiEventPayload } from './types'
 
@@ -98,6 +102,25 @@ export function AiWorkspace({ kind }: { kind: AiKind }) {
   const setFeedback = useAiStore((s) => s.setFeedback)
 
   const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? null
+  const addressInputRef = useRef<HTMLInputElement>(null)
+  const [addressValue, setAddressValue] = useState('')
+
+  useEffect(() => {
+    if (kind !== 'claude' || document.activeElement === addressInputRef.current) return
+    setAddressValue(activeTab?.allowExternalBrowsing ? activeTab.url : '')
+  }, [kind, activeTabId, activeTab?.allowExternalBrowsing, activeTab?.url])
+
+  useEffect(() => {
+    if (kind !== 'claude') return
+    const focusAddressBar = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 'l') return
+      event.preventDefault()
+      addressInputRef.current?.focus()
+      addressInputRef.current?.select()
+    }
+    window.addEventListener('keydown', focusAddressBar)
+    return () => window.removeEventListener('keydown', focusAddressBar)
+  }, [kind])
 
   // 代理检测面板 (展示该页面流量是否全部经代理)。作为宿主上方的可折叠块渲染,
   // 这样不会被原生 webview 盖住 (centered Dialog 会被原生 view 覆盖)。
@@ -248,7 +271,9 @@ export function AiWorkspace({ kind }: { kind: AiKind }) {
       const tab = store.tabsByKind[kind].find((item) => item.id === store.activeTabIdByKind[kind])
       if (!tab) return
       const userAgent = embeddedUserAgent()
-      const lastUrl = normalizeUrlFor(kind, tab.url || homeUrlFor(kind))
+      const lastUrl = tab.allowExternalBrowsing
+        ? normalizeHttpUrl(tab.url)
+        : normalizeUrlFor(kind, tab.url || homeUrlFor(kind))
       const payload = (await api.ensureAiWorkspace({
         kind,
         tabId: tab.id,
@@ -259,6 +284,7 @@ export function AiWorkspace({ kind }: { kind: AiKind }) {
         lastUrl,
         userAgent,
         forceReload,
+        allowExternalBrowsing: tab.allowExternalBrowsing,
       })) as AiEventPayload | null
       if (payload && safeText(payload.tabId)) {
         useAiStore.getState().patchTab(kind, safeText(payload.tabId), {
@@ -350,6 +376,29 @@ export function AiWorkspace({ kind }: { kind: AiKind }) {
       setFeedback(kind, err instanceof Error ? err.message : String(err), 'error')
     }
   }, [kind, senderRunning, ensureWorkspace, setFeedback])
+
+  const openWebPage = useCallback(async () => {
+    if (kind !== 'claude') return
+    const url = normalizeHttpUrl(addressValue, { assumeHttps: true })
+    if (!url) {
+      setFeedback(kind, '请输入有效的 HTTP 或 HTTPS 网址', 'error')
+      return
+    }
+
+    try {
+      const payload = (await api.createAiView(kind, {
+        lastUrl: url,
+        title: new URL(url).hostname,
+        allowExternalBrowsing: true,
+      })) as AiEventPayload
+      applyAiTabsPayload(kind, payload)
+      setAddressValue(url)
+      setFeedback(kind, '')
+      if (senderRunning) await ensureWorkspace()
+    } catch (err) {
+      setFeedback(kind, err instanceof Error ? err.message : String(err), 'error')
+    }
+  }, [kind, addressValue, senderRunning, ensureWorkspace, setFeedback])
 
   const switchTab = useCallback(
     async (tabId: string) => {
@@ -550,6 +599,44 @@ export function AiWorkspace({ kind }: { kind: AiKind }) {
             </Button>
           </div>
         </div>
+
+        {kind === 'claude' && (
+          <form
+            className="flex shrink-0 items-center gap-2 border-b border-border bg-muted/20 px-3 py-1.5"
+            onSubmit={(event) => {
+              event.preventDefault()
+              void openWebPage()
+            }}
+          >
+            <Globe2 className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            <Input
+              ref={addressInputRef}
+              data-testid="claude-address-input"
+              type="text"
+              inputMode="url"
+              value={addressValue}
+              onChange={(event) => setAddressValue(event.target.value)}
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              placeholder="输入网址"
+              aria-label="网页地址"
+              disabled={!senderRunning}
+              className="h-8 min-w-0 flex-1 font-mono text-xs"
+            />
+            <Button
+              type="submit"
+              variant="ghost"
+              size="icon"
+              className="size-8 shrink-0"
+              title="在新标签页打开"
+              aria-label="在新标签页打开"
+              disabled={!senderRunning || !addressValue.trim()}
+            >
+              <ArrowUpRight className="size-4" />
+            </Button>
+          </form>
+        )}
 
         {/* Claude 提示: 不用就别打开此页, 防止潜在网络问题。可关闭(持久化 ui.claude_notice_dismissed)。 */}
         {kind === 'claude' && !settings?.ui?.claude_notice_dismissed && (

--- a/src/renderer-next/src/components/panels/ai/constants.ts
+++ b/src/renderer-next/src/components/panels/ai/constants.ts
@@ -68,6 +68,22 @@ export const CLAUDE_ALLOWED_HOSTS = [
   'intercomcdn.com',
 ]
 
+export function normalizeHttpUrl(rawUrl: string, options: { assumeHttps?: boolean } = {}): string {
+  let value = String(rawUrl || '').trim()
+  if (!value) return ''
+  if (options.assumeHttps && !/^[a-z][a-z\d+.-]*:/i.test(value)) {
+    value = `https://${value}`
+  }
+
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return ''
+    return url.toString()
+  } catch {
+    return ''
+  }
+}
+
 export function isAllowedUrlForHosts(rawUrl: string, allowedHosts: string[]): boolean {
   try {
     const url = new URL(String(rawUrl || ''))

--- a/src/renderer-next/src/components/panels/ai/types.ts
+++ b/src/renderer-next/src/components/panels/ai/types.ts
@@ -12,6 +12,7 @@ export interface AiEventPayload {
   initialized?: boolean
   canGoBack?: boolean
   canGoForward?: boolean
+  allowExternalBrowsing?: boolean
   // tabs-changed
   tabs?: AiTabPayload[]
   activeTabId?: string
@@ -34,6 +35,7 @@ export interface AiTabPayload {
   initialized?: boolean
   canGoBack?: boolean
   canGoForward?: boolean
+  allowExternalBrowsing?: boolean
 }
 
 // ai:ensure / ai:sync-host 返回的单视图状态。
@@ -46,6 +48,7 @@ export interface AiStatePayload {
   initialized?: boolean
   canGoBack?: boolean
   canGoForward?: boolean
+  allowExternalBrowsing?: boolean
 }
 
 export interface SyncHostBounds {

--- a/src/renderer-next/src/components/panels/ai/useAiEvents.ts
+++ b/src/renderer-next/src/components/panels/ai/useAiEvents.ts
@@ -12,6 +12,7 @@ import {
   normalizeGptUrl,
   normalizeGeminiUrl,
   normalizeClaudeUrl,
+  normalizeHttpUrl,
 } from './constants'
 import type { AiEventPayload, AiTabPayload } from './types'
 
@@ -68,10 +69,14 @@ function persistLastUrl(section: AiKind, url: string) {
 function normalizeTab(kind: AiKind, item: AiTabPayload): AiTab | null {
   const id = safeText(item?.id || item?.tabId)
   if (!id) return null
+  const allowExternalBrowsing = kind === 'claude' && Boolean(item.allowExternalBrowsing)
   return {
     id,
     title: safeText(item?.title) || defaultTitleFor(kind),
-    url: normalizeUrlFor(kind, safeText(item?.url)),
+    url: allowExternalBrowsing
+      ? normalizeHttpUrl(safeText(item?.url)) || normalizeClaudeUrl('')
+      : normalizeUrlFor(kind, safeText(item?.url)),
+    allowExternalBrowsing,
     webviewInitialized: Boolean(item?.initialized),
     webviewLoading: Boolean(item?.loading),
     canGoBack: Boolean(item?.canGoBack),
@@ -104,8 +109,17 @@ function applyState(kind: AiKind, payload: AiEventPayload) {
   const store = useAiStore.getState()
   const tabId = safeText(payload.tabId) || store.activeTabIdByKind[kind]
   if (!tabId) return
+  const currentTab = store.tabsByKind[kind].find((item) => item.id === tabId)
+  const allowExternalBrowsing =
+    kind === 'claude' &&
+    (typeof payload.allowExternalBrowsing === 'boolean'
+      ? payload.allowExternalBrowsing
+      : Boolean(currentTab?.allowExternalBrowsing))
 
   const patch: Partial<AiTab> = {}
+  if (typeof payload.allowExternalBrowsing === 'boolean') {
+    patch.allowExternalBrowsing = allowExternalBrowsing
+  }
   if (typeof payload.initialized === 'boolean') patch.webviewInitialized = payload.initialized
   if (typeof payload.loading === 'boolean') patch.webviewLoading = payload.loading
   if (typeof payload.canGoBack === 'boolean') patch.canGoBack = payload.canGoBack
@@ -115,12 +129,19 @@ function applyState(kind: AiKind, payload: AiEventPayload) {
   if (nextTitle) patch.title = nextTitle
 
   const nextUrl = safeText(payload.url)
-  if (nextUrl && isAllowedUrlFor(kind, nextUrl)) patch.url = normalizeUrlFor(kind, nextUrl)
+  const normalizedUrl = allowExternalBrowsing
+    ? normalizeHttpUrl(nextUrl)
+    : isAllowedUrlFor(kind, nextUrl)
+      ? normalizeUrlFor(kind, nextUrl)
+      : ''
+  if (normalizedUrl) patch.url = normalizedUrl
 
   if (Object.keys(patch).length) store.patchTab(kind, tabId, patch)
 
   // 旧 rememberGptUrl/rememberGeminiUrl: 仅活动标签的 url 变更写回 last_url。
-  if (patch.url && tabId === store.activeTabIdByKind[kind]) persistLastUrl(kind, patch.url)
+  if (patch.url && tabId === store.activeTabIdByKind[kind] && !allowExternalBrowsing) {
+    persistLastUrl(kind, patch.url)
+  }
 }
 
 // 解析注入脚本通过 console.log 发回的查询事件 (按 kind 校验各自的标记)。

--- a/src/renderer-next/src/store/useAiStore.ts
+++ b/src/renderer-next/src/store/useAiStore.ts
@@ -10,6 +10,7 @@ export interface AiTab {
   id: string
   title: string
   url: string
+  allowExternalBrowsing: boolean
   webviewInitialized: boolean
   webviewLoading: boolean
   canGoBack: boolean


### PR DESCRIPTION
## 改动说明

在 Claude 工作区增加网址输入栏，可将 HTTP/HTTPS 验证链接或登录链接直接打开为新的内部标签页。

- 仅显式创建的 Claude 网页标签允许访问任意 HTTP/HTTPS 地址
- 普通 Claude、ChatGPT、Gemini 标签继续使用原有域名白名单
- 拒绝 file、javascript、data 等非网页协议
- 外部网页地址不写入持久化 last_url，继续使用现有代理和会话隔离
- UI 集成验证覆盖地址栏渲染及代理停止时的禁用状态

## 关联 issue

无

## 改动类型

- [ ] fix：修复 Bug
- [x] feat：新增功能
- [ ] refactor：重构（不改变外部行为）
- [ ] perf：性能优化
- [ ] docs：文档
- [ ] build / chore：构建、依赖、杂项
- [x] test：测试

## 涉及端

- [x] 客户端（主进程 `src/main/` / 渲染层 `src/renderer-next/`）
- [ ] 协作服务端 `collab_server2/`
- [ ] 管理控制台 `admin_console/`

## 自测清单

- [x] 渲染层 / 管理端 UI：相关目录已跑 `npx tsc -b` 且通过
- [x] 主进程 / 服务端：改动文件已过 `node --check`
- [x] 涉及范围的测试已补充并跑通（25/25）
- [x] 已本地构建 / 运行验证（含 Electron 浏览器隐私与 UI 集成验证）
- [x] 提交信息遵循 Conventional Commits
- [x] 未提交第三方二进制 / 密钥 / 节点配置 / `private.defaults.local.json`

## 影响确认

- [ ] 本改动不影响现有功能行为
- [x] 或：本改动会影响以下行为（请说明）：

Claude 页面新增手动网址入口。权限仅授予通过该入口创建的 Claude 标签；外部页面仍禁止敏感网页权限，且所有请求继续经过当前 AI 会话代理。