### PR TITLE
release: prepare ShareGPT 1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-08-20
+
+> **Claude 网页入口更新**：需要验证码、登录或授权页面时，可从 Claude 工具栏按需打开网页；输入区默认隐藏，不影响日常对话视野。建议使用 Claude 网页的用户升级。
+
+### 新增
+
+- Claude 顶部工具栏新增“打开网页”按钮，点击后才展开网址输入区；提交成功、再次点击或按 `Esc` 后自动收起。
+- 输入的 HTTP/HTTPS 地址会在新的内部标签页打开，继续复用当前 Claude 会话代理，并保留后退、前进、刷新和多标签操作。
+
+### 安全与隐私
+
+- 只有从该入口显式创建的 Claude 网页标签可访问任意 HTTP/HTTPS 地址；普通 Claude 标签及 ChatGPT、Gemini 标签继续使用原有域名白名单。
+- 拒绝 `file:`、`javascript:`、`data:` 等非网页协议；手动输入的验证链接不写入持久化 `last_url`，外部页面也不会获得地理位置等敏感网页权限。
+
+### 修复与验证
+
+- 修复创建网页标签时重复初始化可能触发 `ERR_ABORTED` 的竞态。
+- 新增 URL 协议/权限单元测试，以及默认隐藏、按需展开、打开新标签后自动收起的 Electron UI 回归测试。
+
 ## [1.0.7] - 2026-08-20
 
 > **运行时与跨平台兼容更新**：升级 Electron/Chromium，修复 Mac 继承旧版 Windows 环境预设后的平台矛盾，并加强双平台正式包校验。建议升级。
@@ -200,7 +219,8 @@
 
 - 更早的 5.x 为测试版本，不在此正式记录。
 
-[Unreleased]: https://github.com/Sjeary/ShareGPT/compare/v1.0.7...HEAD
+[Unreleased]: https://github.com/Sjeary/ShareGPT/compare/v1.0.8...HEAD
+[1.0.8]: https://github.com/Sjeary/ShareGPT/compare/v1.0.7...v1.0.8
 [1.0.7]: https://github.com/Sjeary/ShareGPT/compare/v1.0.6...v1.0.7
 [1.0.6]: https://github.com/Sjeary/ShareGPT/compare/v1.0.5...v1.0.6
 [1.0.5]: https://github.com/Sjeary/ShareGPT/compare/v1.0.4...v1.0.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sharegpt-desktop",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sharegpt-desktop",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "chokidar": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharegpt-desktop",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "ShareGPT desktop client with built-in messaging and embedded ChatGPT, Gemini and Claude web access (Gemini/Claude optional).",
   "main": "src/main/main.js",
   "author": "Sjeary",

--- a/scripts/verify-browser-privacy-ui.js
+++ b/scripts/verify-browser-privacy-ui.js
@@ -92,7 +92,12 @@ async function main() {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sharegpt-privacy-ui-"));
   const userDataDir = path.join(tempDir, "user-data");
   const screenshotPath = path.join(tempDir, "browser-privacy-account.png");
-  const claudeScreenshotPath = path.join(tempDir, "claude-address-bar.png");
+  const claudeScreenshotPath = path.join(tempDir, "claude-web-action.png");
+  const claudeExpandedScreenshotPath = path.join(tempDir, "claude-web-action-expanded.png");
+  const upstreamSocksPort = Number.parseInt(
+    String(process.env.SHAREGPT_TEST_UPSTREAM_SOCKS_PORT || ""),
+    10,
+  );
   const port = await reservePort();
   const baseUrl = `http://127.0.0.1:${port}`;
   const usersFile = path.join(tempDir, "users.json");
@@ -241,30 +246,74 @@ async function main() {
 
     await window.screenshot({ path: screenshotPath, fullPage: true });
 
+    if (Number.isInteger(upstreamSocksPort) && upstreamSocksPort > 0) {
+      const localSenderPort = await reservePort();
+      await window.evaluate(
+        ({ socksPort, upstreamPort }) =>
+          window.api.startSender({
+            socks_listen_port: String(socksPort),
+            fallback_mode: "direct",
+            proxy_mode: "airport",
+            airport_name: "Local UI verification chain",
+            airport_outbound: {
+              type: "socks",
+              server: "127.0.0.1",
+              server_port: upstreamPort,
+            },
+            target_domains: "claude.ai",
+          }),
+        { socksPort: localSenderPort, upstreamPort: upstreamSocksPort },
+      );
+    }
+
     await window.locator('[data-tour="nav-claude"]').click();
     const claudeAddressInput = window.getByTestId("claude-address-input");
-    await claudeAddressInput.waitFor({ state: "visible" });
     assert.strictEqual(
-      await claudeAddressInput.isDisabled(),
-      true,
-      "Claude address input must stay disabled while the sender proxy is stopped",
+      await claudeAddressInput.count(),
+      0,
+      "Claude address input must stay hidden until the user opens it",
     );
     const openWebPageButton = window.getByRole("button", {
-      name: "在新标签页打开",
+      name: "打开网页",
       exact: true,
     });
-    assert.strictEqual(
-      await openWebPageButton.isDisabled(),
-      true,
-      "Claude open-page action must stay disabled while the sender proxy is stopped",
-    );
+    const interactiveClaudeCheck = Number.isInteger(upstreamSocksPort) && upstreamSocksPort > 0;
+    if (interactiveClaudeCheck) {
+      const deadline = Date.now() + 5000;
+      while (!(await openWebPageButton.isEnabled()) && Date.now() < deadline) {
+        await window.waitForTimeout(100);
+      }
+      assert.strictEqual(
+        await openWebPageButton.isEnabled(),
+        true,
+        "Claude open-page action must become available after the sender starts",
+      );
+      await openWebPageButton.click();
+      await claudeAddressInput.waitFor({ state: "visible" });
+      await window.screenshot({ path: claudeExpandedScreenshotPath, fullPage: true });
+      await claudeAddressInput.fill(`${baseUrl}/api/health`);
+      await window.getByRole("button", { name: "在新标签页打开", exact: true }).click();
+      await claudeAddressInput.waitFor({ state: "detached" });
+    } else {
+      assert.strictEqual(
+        await openWebPageButton.isDisabled(),
+        true,
+        "Claude open-page action must stay disabled while the sender proxy is stopped",
+      );
+    }
     await window.screenshot({ path: claudeScreenshotPath, fullPage: true });
 
     assert.deepStrictEqual(pageErrors, [], `renderer page errors: ${pageErrors.join("; ")}`);
-    assert.ok(
-      blockedRequests.every((url) => !/claude\.ai|chatgpt\.com|gemini\.google\.com/i.test(url)),
-      `an AI website was requested: ${blockedRequests.join(", ")}`,
+    const aiWebsiteRequests = blockedRequests.filter((url) =>
+      /claude\.ai|chatgpt\.com|gemini\.google\.com/i.test(url),
     );
+    if (!interactiveClaudeCheck) {
+      assert.deepStrictEqual(
+        aiWebsiteRequests,
+        [],
+        `an AI website was requested: ${blockedRequests.join(", ")}`,
+      );
+    }
 
     process.stdout.write(
       `${JSON.stringify(
@@ -282,11 +331,14 @@ async function main() {
           fingerprintPolicySynced: true,
           fingerprintSnapshotsSynced: false,
           syncedNodeDetectionFields: false,
-          aiWebsitesVisited: false,
+          aiWebsitesVisited: aiWebsiteRequests.length > 0,
           blockedNonLocalRequests: blockedRequests.length,
           screenshot: screenshotPath,
-          claudeAddressBarPresent: true,
-          claudeAddressBarScreenshot: claudeScreenshotPath,
+          claudeWebActionPresent: true,
+          claudeAddressInputHiddenByDefault: true,
+          claudeAddressInputToggled: interactiveClaudeCheck,
+          claudeWebActionScreenshot: claudeScreenshotPath,
+          claudeExpandedScreenshot: interactiveClaudeCheck ? claudeExpandedScreenshotPath : null,
         },
         null,
         2,

--- a/src/renderer-next/src/components/layout/Sidebar.tsx
+++ b/src/renderer-next/src/components/layout/Sidebar.tsx
@@ -130,7 +130,7 @@ export function Sidebar({ hidden = false }: { hidden?: boolean }) {
           <div className="whitespace-nowrap font-medium text-foreground">
             {((meta?.productName as string) || 'ShareGPT').replace(/\s+(Sender|Receiver)$/i, '')}
           </div>
-          <div className="whitespace-nowrap">v{(meta?.version as string) || '1.0.7'}</div>
+          <div className="whitespace-nowrap">v{(meta?.version as string) || '1.0.8'}</div>
         </div>
       </aside>
     </TooltipProvider>

--- a/src/renderer-next/src/components/panels/account/changelog.ts
+++ b/src/renderer-next/src/components/panels/account/changelog.ts
@@ -10,6 +10,16 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '1.0.8',
+    date: '2026-08-20',
+    highlights: [
+      'Claude 工具栏新增按需打开网页入口，可在新的内部标签页访问验证码、登录或授权链接；输入区默认完全隐藏，不占用页面空间。',
+      '手动网页标签仅接受 HTTP/HTTPS 地址，继续通过当前本地代理访问；普通 Claude、ChatGPT 和 Gemini 标签仍保留原有域名白名单。',
+      '验证链接不会写入持久化页面记录，外部网页也不会获得地理位置等敏感网页权限。',
+      '修复创建网页标签时重复初始化可能导致 ERR_ABORTED 的问题，并补充默认隐藏与真实代理链路 UI 回归测试。',
+    ],
+  },
+  {
     version: '1.0.7',
     date: '2026-08-20',
     highlights: [

--- a/src/renderer-next/src/components/panels/ai/AiWorkspace.tsx
+++ b/src/renderer-next/src/components/panels/ai/AiWorkspace.tsx
@@ -104,6 +104,11 @@ export function AiWorkspace({ kind }: { kind: AiKind }) {
   const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? null
   const addressInputRef = useRef<HTMLInputElement>(null)
   const [addressValue, setAddressValue] = useState('')
+  const [webAddressOpen, setWebAddressOpen] = useState(false)
+
+  useEffect(() => {
+    if (!senderRunning) setWebAddressOpen(false)
+  }, [senderRunning])
 
   useEffect(() => {
     if (kind !== 'claude' || document.activeElement === addressInputRef.current) return
@@ -111,16 +116,24 @@ export function AiWorkspace({ kind }: { kind: AiKind }) {
   }, [kind, activeTabId, activeTab?.allowExternalBrowsing, activeTab?.url])
 
   useEffect(() => {
-    if (kind !== 'claude') return
+    if (kind !== 'claude' || !senderRunning) return
     const focusAddressBar = (event: KeyboardEvent) => {
       if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 'l') return
       event.preventDefault()
-      addressInputRef.current?.focus()
-      addressInputRef.current?.select()
+      setWebAddressOpen(true)
     }
     window.addEventListener('keydown', focusAddressBar)
     return () => window.removeEventListener('keydown', focusAddressBar)
-  }, [kind])
+  }, [kind, senderRunning])
+
+  useEffect(() => {
+    if (!webAddressOpen) return
+    const frame = window.requestAnimationFrame(() => {
+      addressInputRef.current?.focus()
+      addressInputRef.current?.select()
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [webAddressOpen])
 
   // 代理检测面板 (展示该页面流量是否全部经代理)。作为宿主上方的可折叠块渲染,
   // 这样不会被原生 webview 盖住 (centered Dialog 会被原生 view 覆盖)。
@@ -393,12 +406,12 @@ export function AiWorkspace({ kind }: { kind: AiKind }) {
       })) as AiEventPayload
       applyAiTabsPayload(kind, payload)
       setAddressValue(url)
+      setWebAddressOpen(false)
       setFeedback(kind, '')
-      if (senderRunning) await ensureWorkspace()
     } catch (err) {
       setFeedback(kind, err instanceof Error ? err.message : String(err), 'error')
     }
-  }, [kind, addressValue, senderRunning, ensureWorkspace, setFeedback])
+  }, [kind, addressValue, setFeedback])
 
   const switchTab = useCallback(
     async (tabId: string) => {
@@ -429,7 +442,7 @@ export function AiWorkspace({ kind }: { kind: AiKind }) {
   )
 
   // 运行态 / 遮罩内容变化时, 重新同步宿主定位。
-  const overlayKey = `${senderRunning}|${activeTabId}|${view.initialized}|${proxyOpen}|${proxyReport?.hosts?.length ?? 0}|${feedback.text ? 1 : 0}`
+  const overlayKey = `${senderRunning}|${activeTabId}|${view.initialized}|${webAddressOpen}|${proxyOpen}|${proxyReport?.hosts?.length ?? 0}|${feedback.text ? 1 : 0}`
   const overlayRef = useRef(overlayKey)
   useEffect(() => {
     if (overlayRef.current !== overlayKey) {
@@ -533,6 +546,20 @@ export function AiWorkspace({ kind }: { kind: AiKind }) {
           />
 
           <div className="ml-auto flex shrink-0 items-center gap-1">
+            {kind === 'claude' && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn('size-8', webAddressOpen && 'bg-accent text-accent-foreground')}
+                title={webAddressOpen ? '收起网址输入' : '打开网页'}
+                aria-label={webAddressOpen ? '收起网址输入' : '打开网页'}
+                aria-pressed={webAddressOpen}
+                disabled={!senderRunning}
+                onClick={() => setWebAddressOpen((open) => !open)}
+              >
+                <Globe2 className="size-4" />
+              </Button>
+            )}
             <Badge
               variant="outline"
               title="当前代理方式（统一梯子 / 服务器下发的机场节点）"
@@ -600,12 +627,15 @@ export function AiWorkspace({ kind }: { kind: AiKind }) {
           </div>
         </div>
 
-        {kind === 'claude' && (
+        {kind === 'claude' && webAddressOpen && (
           <form
             className="flex shrink-0 items-center gap-2 border-b border-border bg-muted/20 px-3 py-1.5"
             onSubmit={(event) => {
               event.preventDefault()
               void openWebPage()
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') setWebAddressOpen(false)
             }}
           >
             <Globe2 className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />


### PR DESCRIPTION
## 变更

- Claude 工具栏新增按需展开的网页入口，默认不占用页面空间
- 仅允许 HTTP/HTTPS，并在新内部标签页复用当前 Claude 代理
- 修复重复初始化导致的 ERR_ABORTED 竞态
- 更新桌面客户端版本与两处更新日志至 1.0.8

## 验证

- 本地 CI 等价校验通过
- Electron UI 默认隐藏与真实代理交互回归通过
- macOS arm64 DMG 构建成功，本机安装启动通过
- Windows x64 portable 原生构建及 15 秒启动冒烟通过
- Windows x64 NSIS 原生构建，verify:release-win 返回 ok=true / target=nsis

## 合并约束

此 PR 仅供审查与 GitHub Actions 验证。未经维护者明确授权，不合并到 main、不打 tag、不发布 Release。